### PR TITLE
Update Snapshot test after passing down another prop to fetch DELETE network request

### DIFF
--- a/src/App/__snapshots__/App.test.js.snap
+++ b/src/App/__snapshots__/App.test.js.snap
@@ -19,6 +19,7 @@ exports[`APP should match App Snapshot 1`] = `
     className="resy-container"
   >
     <ReservationsContainer
+      fetchWithDelete={[Function]}
       reservations={Array []}
     />
   </div>


### PR DESCRIPTION
This PR fixes the one Snapshot test that is failing currently.